### PR TITLE
add appimage support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
   "type": "module",
   "scripts": {
     "start": "electron .",
-    "dist": "electron-builder --linux snap"
+    "dist:all": "electron-builder --linux snap AppImage",
+    "dist:snap": "electron-builder --linux snap",
+    "dist:appimage": "electron-builder --linux AppImage"
   },
   "build": {
     "appId": "com.example.notiondesktopclient",
     "linux": {
-      "target": "snap",
+      "target": ["snap", "AppImage"],
       "icon": "assets/icon.png",
       "category": "Utility"
     }


### PR DESCRIPTION
adds support for building an appimage via electron-builder

resolves #3 